### PR TITLE
Update ethers dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
     "ethcall": "^6.0.0",
-    "ethers": "^6.3.0",
+    "ethers": "^6.6.0",
     "memoizee": "^0.4.15"
   }
 }


### PR DESCRIPTION
If version of ethers is lower it won't support Tenderly RPCs for init, we'd need this published on npm