### PR TITLE
Fix volumeNetworks import

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Contract } from 'ethers';
 import { Contract as MulticallContract } from "ethcall";
 import BigNumber from 'bignumber.js';
-import {IChainId, IDict, INetworkName, IRewardFromApi, IVolumeAndAPYs, REFERENCE_ASSET} from './interfaces';
+import { IChainId, IDict, INetworkName, IRewardFromApi, IVolumeAndAPYs, REFERENCE_ASSET } from './interfaces';
 import { curve, NETWORK_CONSTANTS } from "./curve.js";
 import {
     _getAllPoolsFromApi,
@@ -12,7 +12,7 @@ import {
 } from "./external-api.js";
 import ERC20Abi from './constants/abis/ERC20.json' assert { type: 'json' };
 import { L2Networks } from './constants/L2Networks.js';
-import {volumeNetworks} from "./constants/volumeNetworks";
+import { volumeNetworks } from "./constants/volumeNetworks.js";
 
 
 export const ETH_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";


### PR DESCRIPTION
When running scripts using `ts-node`, the library produces the following error:
```
ts-node scripts/curve.ts

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/MyProject/node_modules/@curvefi/api/lib/constants/volumeNetworks' imported from /MyProject/node_modules/@curvefi/api/lib/utils.js
    at new NodeError (node:internal/errors:387:5)
    at finalizeResolution (node:internal/modules/esm/resolve:330:11)
    at moduleResolve (node:internal/modules/esm/resolve:907:10)
    at defaultResolve (node:internal/modules/esm/resolve:1115:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:841:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:40)
    at link (node:internal/modules/esm/module_job:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

A minimum reproducible example can be found here https://stackblitz.com/edit/stackblitz-starters-blfcep

This issue is caused by the missing `.js` extension for `volumeNetworks` import, which is also inconsistent with the rest of the imports in the repository.