### PR TITLE
perf: avoid initializing ethers contracts during construction

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,24 +18,25 @@
   },
   "type": "module",
   "devDependencies": {
-    "@types/chai": "^4.3.4",
-    "@types/memoizee": "^0.4.7",
-    "@types/mocha": "^10.0.1",
-    "@types/node": "^14.14.37",
-    "@typescript-eslint/eslint-plugin": "^4.33.0",
-    "@typescript-eslint/parser": "^4.20.0",
+    "@types/chai": "^4.3.19",
+    "@types/memoizee": "^0.4.11",
+    "@types/mocha": "^10.0.7",
+    "@types/node": "^22.5.1",
+    "@typescript-eslint/eslint-plugin": "^8.3.0",
+    "@typescript-eslint/parser": "^8.3.0",
     "babel-eslint": "^10.1.0",
-    "chai": "^4.3.7",
-    "eslint": "^7.32.0",
-    "mocha": "^10.2.0",
-    "typescript": "^4.5.2",
-    "vue-eslint-parser": "^7.6.0"
+    "chai": "^5.1.1",
+    "eslint": "^9.9.1",
+    "mocha": "^10.7.3",
+    "typescript": "^5.5.4",
+    "vue-eslint-parser": "^9.4.3"
   },
   "dependencies": {
-    "axios": "^0.21.1",
-    "bignumber.js": "^9.0.1",
     "@curvefi/ethcall": "6.0.7",
-    "ethers": "^6.11.0",
-    "memoizee": "^0.4.15"
+    "abitype": "^1.0.6",
+    "axios": "^0.21.1",
+    "bignumber.js": "^9.1.2",
+    "ethers": "^6.13.2",
+    "memoizee": "^0.4.17"
   }
 }

--- a/src/curve.ts
+++ b/src/curve.ts
@@ -6,6 +6,7 @@ import {
     Numeric,
     AbstractProvider,
 } from "ethers";
+import type { Abi } from "abitype";
 import { Provider as MulticallProvider, Contract as MulticallContract } from "@curvefi/ethcall";
 import { getFactoryPoolData } from "./factory/factory.js";
 import { getFactoryPoolsDataFromApi } from "./factory/factory-api.js";
@@ -106,7 +107,7 @@ import { lowerCasePoolDataAddresses, extractDecimals, extractGauges } from "./co
 import { _getAllGauges, _getHiddenPools } from "./external-api.js";
 import { L2Networks } from "./constants/L2Networks.js";
 import { getTwocryptoFactoryPoolData } from "./factory/factory-twocrypto.js";
-import {getGasInfoForL2, memoizedContract, memoizedMulticallContract} from "./utils.js";
+import { memoizedContract, memoizedMulticallContract } from "./utils.js";
 
 const _killGauges = async (poolsData: IDict<IPoolData>): Promise<void> => {
     const gaugeData = await _getAllGauges();
@@ -408,13 +409,16 @@ export const NETWORK_CONSTANTS: { [index: number]: any } = {
 
 const OLD_CHAINS = [1, 10, 56, 100, 137, 250, 1284, 2222, 8453, 42161, 42220, 43114, 1313161554];  // these chains have non-ng pools
 
+
+export type ContractItem = { contract: Contract, multicallContract: MulticallContract, abi: Abi };
+
 class Curve implements ICurve {
     provider: ethers.BrowserProvider | ethers.JsonRpcProvider;
     multicallProvider: MulticallProvider;
     signer: ethers.Signer | null;
     signerAddress: string;
     chainId: IChainId;
-    contracts: { [index: string]: { contract: Contract, multicallContract: MulticallContract } };
+    contracts: { [index: string]: ContractItem };
     feeData: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number };
     constantOptions: { gasLimit?: number };
     options: { gasPrice?: number | bigint, maxFeePerGas?: number | bigint, maxPriorityFeePerGas?: number | bigint };

--- a/src/pools/PoolTemplate.ts
+++ b/src/pools/PoolTemplate.ts
@@ -256,9 +256,8 @@ export class PoolTemplate {
     public rewardsOnly(): boolean {
         if (curve.chainId === 2222 || curve.chainId === 324) return true;  // TODO remove this for Kava and ZkSync
         if (this.gauge.address === curve.constants.ZERO_ADDRESS) throw Error(`${this.name} doesn't have gauge`);
-        const gaugeContract = curve.contracts[this.gauge.address].contract;
-
-        return !('inflation_rate()' in gaugeContract || 'inflation_rate(uint256)' in gaugeContract);
+        return !findAbiFunction(curve.contracts[this.gauge.address].abi, 'inflation_rate')
+            .find((func) => ['', 'uint256'].includes(func.inputs.map(a => `${a.type}`).join(',')))
     }
 
     private statsParameters = async (): Promise<{

--- a/src/pools/PoolTemplate.ts
+++ b/src/pools/PoolTemplate.ts
@@ -27,7 +27,7 @@ import {
     smartNumber,
     DIGas,
     _getAddress,
-    isMethodExist,
+    findAbiFunction,
     getVolumeApiController,
 } from '../utils.js';
 import {IDict, IReward, IProfit, IPoolType} from '../interfaces';
@@ -2323,8 +2323,7 @@ export class PoolTemplate {
         }
 
         //for crvusd and stable-ng implementations
-        const isUseStoredRates = isMethodExist(curve.contracts[this.address].contract, 'stored_rates') && this.isPlain;
-        if (isUseStoredRates) {
+        if (findAbiFunction(curve.contracts[this.address].abi, 'stored_rates').length > 0 && this.isPlain) {
             const _stored_rates: bigint[] = await curve.contracts[this.address].contract.stored_rates();
             return _stored_rates.map((_r, i) => toBN(_r, 36 - this.wrappedDecimals[i]));
         }

--- a/src/pools/poolConstructor.ts
+++ b/src/pools/poolConstructor.ts
@@ -20,7 +20,7 @@ import {
     swapWrappedMixin,
     swapWrappedRequiredMixin,
 } from "./mixins/swapWrappedMixins.js";
-import { getCountArgsOfMethodByContract } from "../utils.js";
+import { getCountArgsOfMethodByAbi, findAbiSignature } from "../utils.js";
 
 
 export const getPool = (poolId: string): PoolTemplate => {
@@ -59,7 +59,7 @@ export const getPool = (poolId: string): PoolTemplate => {
         }
     } else if (poolDummy.zap && poolId !== 'susd') {
         Object.assign(Pool.prototype, depositZapMixin);
-    } else if (getCountArgsOfMethodByContract(curve.contracts[poolDummy.address].contract, 'add_liquidity') > 2) {
+    } else if (getCountArgsOfMethodByAbi(curve.contracts[poolDummy.address].abi, 'add_liquidity') > 2) {
         Object.assign(Pool.prototype, depositLendingOrCryptoMixin);
     } else {
         Object.assign(Pool.prototype, depositPlainMixin);
@@ -92,7 +92,7 @@ export const getPool = (poolId: string): PoolTemplate => {
         }
     } else if (poolDummy.zap && poolId !== 'susd') {
         Object.assign(Pool.prototype, withdrawZapMixin);
-    } else if (getCountArgsOfMethodByContract(curve.contracts[poolDummy.address].contract, 'remove_liquidity') > 2) {
+    } else if (getCountArgsOfMethodByAbi(curve.contracts[poolDummy.address].abi, 'remove_liquidity') > 2) {
         Object.assign(Pool.prototype, withdrawLendingOrCryptoMixin);
     } else {
         Object.assign(Pool.prototype, withdrawPlainMixin);
@@ -151,7 +151,7 @@ export const getPool = (poolId: string): PoolTemplate => {
         }
     } else if (poolDummy.zap) { // including susd
         Object.assign(Pool.prototype, withdrawOneCoinZapMixin);
-    } else if (getCountArgsOfMethodByContract(curve.contracts[poolDummy.address].contract, 'remove_liquidity_one_coin') > 3) {
+    } else if (getCountArgsOfMethodByAbi(curve.contracts[poolDummy.address].abi, 'remove_liquidity_one_coin') > 3) {
         Object.assign(Pool.prototype, withdrawOneCoinLendingOrCryptoMixin);
     } else {
         Object.assign(Pool.prototype, withdrawOneCoinPlainMixin);
@@ -176,7 +176,7 @@ export const getPool = (poolId: string): PoolTemplate => {
     }
 
     // swap and swapEstimateGas
-    if ('exchange(uint256,uint256,uint256,uint256,bool)' in curve.contracts[poolDummy.address].contract &&
+    if (findAbiSignature(curve.contracts[poolDummy.address].abi, 'exchange', 'uint256,uint256,uint256,uint256,bool') &&
         !(curve.chainId === 100 && poolDummy.id === "tricrypto")) { // tricrypto2 (eth), tricrypto (arbitrum), avaxcrypto (avalanche); 100 is xDAI
         Object.assign(Pool.prototype, swapTricrypto2Mixin);
     } else if (poolDummy.isMetaFactory && (getPool(poolDummy.basePool).isLending || getPool(poolDummy.basePool).isFake || poolDummy.isCrypto)) {
@@ -193,7 +193,7 @@ export const getPool = (poolId: string): PoolTemplate => {
     if (!poolDummy.isPlain && !poolDummy.isFake) {
         Object.assign(Pool.prototype, swapWrappedExpectedAndApproveMixin);
         Object.assign(Pool.prototype, swapWrappedRequiredMixin);
-        if ('exchange(uint256,uint256,uint256,uint256,bool)' in curve.contracts[poolDummy.address].contract) { // tricrypto2 (eth), tricrypto (arbitrum)
+        if (findAbiSignature(curve.contracts[poolDummy.address].abi, 'exchange', 'uint256,uint256,uint256,uint256,bool')) { // tricrypto2 (eth), tricrypto (arbitrum)
             Object.assign(Pool.prototype, swapWrappedTricrypto2Mixin);
         } else {
             Object.assign(Pool.prototype, swapWrappedMixin);


### PR DESCRIPTION
- Fixes performance issue
  - When we open curve-frontend, all `Pool` objects are created
  - In the constructor, some other ethers contracts are initialized by calling `curve.contracts[...].contract`
    - We initialize many pools, each pool has many methods
    - When we call ethers `new Contract`, the function `defineProperties` takes ~50% of the render time in the swap page
  - By avoiding the ethers initialization, we can save a lot of CPU time
- Introduced `abitype` for better type checking
  - Update to typescript 5 was necessary
  - Updated other dependencies for good practice
- Replaced contract parsing with abi checking in
  - the poolConstructor - this is called from the swap page
  - the rewardsOnly method - this is called from the pools page