### PR TITLE
test: Basic test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ package-lock.json
 pnpm-lock.yaml
 yarn.lock
 test/temp.test.ts
-test/rpcUrls.test.ts

--- a/README.md
+++ b/README.md
@@ -2462,3 +2462,9 @@ import curve from "@curvefi/api";
     // ]
 })()
 ```
+
+## Tests
+
+```sh
+npm run test
+```

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "rm -rf lib && tsc -p tsconfig.build.json",
+    "test": "npx tsc && mocha dist/test/*.test.js",
     "lint": "eslint src --ext .ts"
   },
   "type": "module",

--- a/test/apy.test.ts
+++ b/test/apy.test.ts
@@ -3,7 +3,7 @@ import curve from "../src/index.js";
 import { curve as _curve } from "../src/curve.js";
 import { getPool, PoolTemplate } from "../src/pools/index.js";
 import { IReward } from "../src/interfaces.js";
-import { ETH_RPC, OPTIMISM_RPC, XDAI_RPC, POLYGON_RPC, FANTOM_RPC, MOONBEAM_RPC, KAVA_RPC, ARBITRUM_RPC, CELO_RPC, AVALANCHE_RPC, AURORA_RPC } from "./rpcUrls.test.js";
+import { ETH_RPC } from "./rpcUrls.test.js";
 
 
 const poolStatsTest = (name: string) => {

--- a/test/factoryPoolsData.test.ts
+++ b/test/factoryPoolsData.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { curve } from "../src/curve.js";
-import { ETH_RPC, ARBITRUM_RPC, AURORA_RPC } from "./rpcUrls.test.js";
+import { ETH_RPC } from "./rpcUrls.test.js";
 import { IDict, IPoolData } from "../src/interfaces.js";
 import { BLACK_LIST } from "../src/factory/factory.js";
 

--- a/test/rpcUrls.test.ts
+++ b/test/rpcUrls.test.ts
@@ -1,0 +1,1 @@
+export const { ETH_RPC } = process.env;


### PR DESCRIPTION
Make sure the tests can be ran easily.
This is the first of a list of change aiming at improving the test setup. We will try to keep the changes simple and iterate rather than making a giant pull request that would be painful to be reviewed and merged.

Note that the `rpcUrls.test.js` file was added back to tracking and leverages `process.env`. Alternatively we could add dotenv as a dev dependency and use (untracked) `.env` files for RPC URLs.

A lot of tests are still failing but at least some pass. Fixing tests will be addressed in follow up pull requests.

Tested with both Hardhat and Anvil exporting `ETH_RPC` as:
```
export ETH_RPC=http://127.0.0.1:8545
```

In follow up pull requests we want to:
- fix or skip broken tests
- run tests from the CI