### PR TITLE
fix: ERR_IMPORT_ASSERTION_TYPE_MISSING, refs #398

### DIFF
--- a/src/curve.ts
+++ b/src/curve.ts
@@ -46,7 +46,7 @@ import gasOracleABI from './constants/abis/gas_oracle_optimism.json' assert { ty
 import gasOracleBlobABI from './constants/abis/gas_oracle_optimism_blob.json' assert { type: 'json'};
 import votingProposalABI from './constants/abis/voting_proposal.json' assert { type: 'json'};
 import circulatingSupplyABI from './constants/abis/circulating_supply.json' assert { type: 'json'};
-import rootGaugeFactoryABI from "./constants/abis/gauge_factory/root_gauge_factory.json";
+import rootGaugeFactoryABI from "./constants/abis/gauge_factory/root_gauge_factory.json" assert { type: 'json'};
 
 
 import {


### PR DESCRIPTION
The error was:
```
TypeError [Error]: Module "file:///project/node_modules/@curvefi/api/lib/constants/abis/gauge_factory/root_gauge_factory.json" needs an import attribute of type "json"
    at validateAttributes (node:internal/modules/esm/assert:89:15)
    at defaultLoad (node:internal/modules/esm/load:153:3)
    at async nextLoad (node:internal/modules/esm/hooks:866:22)
    at async /project/node_modules/ts-node/src/esm.ts:255:39
    at async addShortCircuitFlag (/project/node_modules/ts-node/src/esm.ts:409:15)
    at async nextLoad (node:internal/modules/esm/hooks:866:22)
    at async Hooks.load (node:internal/modules/esm/hooks:449:20)
    at async handleMessage (node:internal/modules/esm/worker:196:18) {
  code: 'ERR_IMPORT_ASSERTION_TYPE_MISSING'
}
```