### PR TITLE
fix: publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,13 +38,17 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup node version
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22.x'
           cache: npm
+          registry-url: 'https://registry.npmjs.org'
       - name: Install modules
         run: npm ci
       - name: Build


### PR DESCRIPTION
- add the registry url
- add missing permissions

based on [github documentation](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry)