### PR TITLE
feat: add isTestnet to curve lite networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/api",
-  "version": "2.65.17",
+  "version": "2.65.18",
   "description": "JavaScript library for curve.fi",
   "main": "lib/index.js",
   "author": "Macket",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/api",
-  "version": "2.65.18",
+  "version": "2.65.17",
   "description": "JavaScript library for curve.fi",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/external-api.ts
+++ b/src/external-api.ts
@@ -1,15 +1,15 @@
 import axios from "axios";
 import memoize from "memoizee";
 import {
-    IExtendedPoolDataFromApi,
-    IDict,
-    INetworkName,
-    IPoolType,
-    IGaugesDataFromApi,
+    ICurveLiteNetwork,
     IDaoProposal,
     IDaoProposalListItem,
+    IDict,
+    IExtendedPoolDataFromApi,
+    IGaugesDataFromApi,
+    INetworkName,
+    IPoolType,
     IVolumeAndAPYs,
-    ICurveLiteNetwork,
 } from "./interfaces";
 
 
@@ -317,24 +317,20 @@ export const _getCurveLiteNetworks = memoize(
         }
 
         const { platforms, platformsMetadata } = response.data.data;
-
-        const networks: ICurveLiteNetwork[] = Object.entries(platforms)
-            .map(([platformId, _factories]) => {
-                const metadata = platformsMetadata[platformId];
-                if (!metadata) return null;
-
+        return Object.keys(platforms)
+            .map(id => {
+                const {explorerBaseUrl, name, rpcUrl, nativeCurrencySymbol, isMainnet, chainId} = platformsMetadata[id];
                 return {
-                    id: platformId,
-                    name: metadata.name,
-                    rpcUrl: metadata.rpcUrl,
-                    chainId: metadata.chainId,
-                    explorerUrl: metadata.explorerBaseUrl,
-                    nativeCurrencySymbol: metadata.nativeCurrencySymbol,
+                    id,
+                    name,
+                    rpcUrl,
+                    chainId,
+                    explorerUrl: explorerBaseUrl,
+                    nativeCurrencySymbol,
+                    isTestnet: !isMainnet,
                 };
             })
-            .filter((network): network is ICurveLiteNetwork => network !== null);
-
-        return networks;
+            .filter(({ name }) => name);
     },
     {
         promise: true,

--- a/src/external-api.ts
+++ b/src/external-api.ts
@@ -318,9 +318,9 @@ export const _getCurveLiteNetworks = memoize(
 
         const { platforms, platformsMetadata } = response.data.data;
         return Object.keys(platforms)
-            .map(id => {
-                const {explorerBaseUrl, name, rpcUrl, nativeCurrencySymbol, isMainnet, chainId} = platformsMetadata[id];
-                return {
+            .map((id) => {
+                const { name, rpcUrl, nativeCurrencySymbol, explorerBaseUrl, isMainnet, chainId} = platformsMetadata[id] ?? {};
+                return name && {
                     id,
                     name,
                     rpcUrl,
@@ -330,7 +330,7 @@ export const _getCurveLiteNetworks = memoize(
                     isTestnet: !isMainnet,
                 };
             })
-            .filter(({ name }) => name);
+            .filter(Boolean);
     },
     {
         promise: true,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -292,6 +292,7 @@ export interface ICurveLiteNetwork {
     rpcUrl: string
     explorerUrl: string
     nativeCurrencySymbol: string
+    isTestnet: boolean
 }
 
 export type TVoteType = "PARAMETER" | "OWNERSHIP"


### PR DESCRIPTION
In order to implement a new network selection component we need to know which networks are test nets
![image](https://github.com/user-attachments/assets/e1848e06-0723-436a-a0ac-82efae987cd1)
