### PR TITLE
fix: typo in fetchTworyptoFactoryPools Method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -263,7 +263,7 @@ const curve = {
         },
     },
     twocryptoFactory: {
-        fetchPools: _curve.fetchTworyptoFactoryPools,
+        fetchPools: _curve.fetchTwocryptoFactoryPools,
         fetchNewPools: _curve.fetchNewTwocryptoFactoryPools,
         getPoolList: _curve.getTworyptoFactoryPoolList,
         deployPool: deployTwocryptoPool,


### PR DESCRIPTION
**Description:**

The method `fetchTworyptoFactoryPools` was mistakenly spelled as "Tworypto," which is incorrect.
It has now been corrected to the proper spelling of "Twocrypto" to ensure consistency and accuracy across the codebase.

**Thanks for Curve!**
