### PR TITLE
fix: json type asserts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/api",
-  "version": "2.66.1",
+  "version": "2.66.2",
   "description": "JavaScript library for curve.fi",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/curve.ts
+++ b/src/curve.ts
@@ -31,7 +31,7 @@ import feeDistributorCrvUSDABI from './constants/abis/fee_distributor_crvusd.jso
 import gaugeControllerABI from './constants/abis/gaugecontroller.json' with { type: 'json' };
 import depositAndStakeABI from './constants/abis/deposit_and_stake.json' with { type: 'json' };
 import depositAndStakeNgOnlyABI from './constants/abis/deposit_and_stake_ng_only.json' with { type: 'json' };
-import cryptoCalcZapABI from './constants/abis/crypto_calc.json' assert { type: 'json'};
+import cryptoCalcZapABI from './constants/abis/crypto_calc.json' with { type: 'json' };
 import StableCalcZapABI from './constants/abis/stable_calc.json' with { type: 'json' };
 import routerABI from './constants/abis/router.json' with { type: 'json' };
 import routerPolygonABI from './constants/abis/routerPolygon.json' with { type: 'json' };
@@ -45,11 +45,11 @@ import twocryptoFactoryABI from './constants/abis/factory-twocrypto-ng.json' wit
 import tricryptoFactoryMainnetABI from './constants/abis/factory-tricrypto-mainnet.json' with { type: 'json' };
 import tricryptoFactorySidechainABI from './constants/abis/factory-tricrypto-sidechain.json' with { type: 'json' };
 import stableNgFactoryABI from './constants/abis/factory-stable-ng.json' with { type: 'json' };
-import gasOracleABI from './constants/abis/gas_oracle_optimism.json' assert { type: 'json'};
-import gasOracleBlobABI from './constants/abis/gas_oracle_optimism_blob.json' assert { type: 'json'};
-import votingProposalABI from './constants/abis/voting_proposal.json' assert { type: 'json'};
-import circulatingSupplyABI from './constants/abis/circulating_supply.json' assert { type: 'json'};
-import rootGaugeFactoryABI from "./constants/abis/gauge_factory/root_gauge_factory.json" assert { type: 'json'};
+import gasOracleABI from './constants/abis/gas_oracle_optimism.json' with { type: 'json' };
+import gasOracleBlobABI from './constants/abis/gas_oracle_optimism_blob.json' with { type: 'json' };
+import votingProposalABI from './constants/abis/voting_proposal.json' with { type: 'json' };
+import circulatingSupplyABI from './constants/abis/circulating_supply.json' with { type: 'json' };
+import rootGaugeFactoryABI from "./constants/abis/gauge_factory/root_gauge_factory.json" with { type: 'json' };
 
 import { lowerCasePoolDataAddresses, extractDecimals, extractGauges } from "./constants/utils.js";
 import {_getHiddenPools} from "./external-api.js";

--- a/src/factory/factory.ts
+++ b/src/factory/factory.ts
@@ -3,7 +3,7 @@ import { curve } from "../curve.js";
 import {IDict, IPoolData, ICurve, REFERENCE_ASSET, IPoolDataShort} from "../interfaces";
 import ERC20ABI from "../constants/abis/ERC20.json" with { type: 'json' };
 import PlainStableSwapNGABI from "../constants/abis/factory-stable-ng/plain-stableswap-ng.json" with { type: 'json' };
-import MetaStableSwapNGABI from "../constants/abis/factory-stable-ng/meta-stableswap-ng.json" assert {type: 'json'};
+import MetaStableSwapNGABI from "../constants/abis/factory-stable-ng/meta-stableswap-ng.json" with { type: 'json' };
 import factoryGaugeABI from "../constants/abis/gauge_factory.json" with { type: 'json' };
 import gaugeChildABI from "../constants/abis/gauge_child.json" with { type: 'json' };
 import StableNgBasePoolZapABI from "../constants/abis/stable-ng-base-pool-zap.json" with { type: 'json' };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,7 @@ import {
     _getSubgraphData,
     _getVolumes,
 } from "./external-api.js";
-import ERC20Abi from './constants/abis/ERC20.json' assert {type: 'json'};
+import ERC20Abi from './constants/abis/ERC20.json' with { type: 'json' };
 import {L2Networks} from './constants/L2Networks.js';
 import {volumeNetworks} from "./constants/volumeNetworks.js";
 import {getPool} from "./pools/index.js";


### PR DESCRIPTION
- `assert {type: 'json'}` was used in node 16, but removed in node 20
- `with {type: 'json'}` was introduced in node 18
