### PR TITLE
fix: support a pools own lp tokens as gauge rewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/api",
-  "version": "2.66.15",
+  "version": "2.66.16",
   "description": "JavaScript library for curve.fi",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/pools/utils.ts
+++ b/src/pools/utils.ts
@@ -174,7 +174,7 @@ const _getUserClaimable = async (pools: string[], address: string, useCache: boo
 
             for (const token of rewardTokens[poolId]) {
                 // Don't reset the reward ABI if the reward is the LP token itself, otherwise we lose LP contract functions
-                const { multicallContract } = token !== pool.address ? _setContracts(token, ERC20Abi) : curve.contracts[token]
+                const { multicallContract } = token === pool.address ? curve.contracts[token] : _setContracts(token, ERC20Abi)
                 rewardInfoCalls.push(multicallContract.symbol(), multicallContract.decimals());
 
                 if ('claimable_reward(address,address)' in gaugeContract) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -696,12 +696,14 @@ export const getVolume = async (chainId = curve.chainId): Promise<{ totalVolume:
     return { totalVolume, cryptoVolume, cryptoShare }
 }
 
-export const _setContracts = (address: string, abi: any): void => {
-    curve.contracts[address] = {
+export const _setContracts = (address: string, abi: any) => {
+    const contracts = {
         abi,
         contract: new Contract(address, abi, curve.signer || curve.provider),
         multicallContract: new MulticallContract(address, abi),
     }
+    curve.contracts[address] = contracts;
+    return contracts;
 }
 
 // Find k for which x * k = target_x or y * k = target_y


### PR DESCRIPTION
When parsing a pool's gauge rewards, if one of the reward tokens was the pool's own LP token, we would lose all pool ABI functionality as the LP token's ABI would be replaced with a vanilla ERC20 abi. This commit does not reset the ABI if the ABI is already set.

**Do not merge until we get an approval by experts as there might be unexpected behavior when accepting a pool's own LP tokens as rewards in the first place**