### PR TITLE
fix: lp token as reward for other pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/api",
-  "version": "2.67.2",
+  "version": "2.67.3",
   "description": "JavaScript library for curve.finance",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/pools/utils.ts
+++ b/src/pools/utils.ts
@@ -172,8 +172,8 @@ async function _getUserClaimable(this: Curve, pools: string[], address: string, 
             }
 
             for (const token of rewardTokens[poolId]) {
-                // Don't reset the reward ABI if the reward is the LP token itself, otherwise we lose LP contract functions
-                const { multicallContract } = token === pool.address ? this.contracts[token] : _setContracts.call(this, token, ERC20Abi)
+                // Don't reset ABI if its already set, we might override an LP token ABI
+                const { multicallContract } = this.contracts[token] || _setContracts.call(this, token, ERC20Abi)
                 rewardInfoCalls.push(multicallContract.symbol(), multicallContract.decimals());
 
                 if ('claimable_reward(address,address)' in gaugeContract) {
@@ -274,8 +274,8 @@ async function _getUserClaimableUseApi(this: Curve, pools: string[], address: st
             }
 
             for (const r of rewardTokens[poolId]) {
-                // Don't reset the reward ABI if the reward is the LP token itself, otherwise we lose LP contract functions
-                if (r.token !== pool.address) {
+                // Don't reset ABI if its already set, we might override an LP token ABI
+                if (!this.contracts[r.token]) {
                     _setContracts.call(this, r.token, ERC20Abi)
                 }
 


### PR DESCRIPTION
We recently fixed a bug where a pool's ABI would be overwritten with just the ERC20 ABI if the pool's gauge had the LP token itself as a reward. If that was the case, the pool would lose all its pool ABI functions.

However, we missed the case where the LP token could also be used as a gauge reward for *other* pools than the pool belonging to the LP token itself.

A specific example on Sonic: the Power Curve pool has the CrossCurve CRV LP token as gauge reward. These are two different pools, and by loading the Power Curve pool data we accidentally reset the CrossCurve CRV ABI to be ERC20. This leads to the following error when trying to withdraw LP tokens from the CrossCurve CRV pool (https://www.curve.finance/dex/sonic/pools/factory-stable-ng-2/withdraw/)
![image](https://github.com/user-attachments/assets/0ed26192-85c8-490f-b2bd-560a1ee943fb)

This PR makes sure that if a contract is already set when adding reward token contracts, it won't be overwritten by the ERC20 ABI anymore, even if the LP token address differs from the pool address.