### PR TITLE
fix: router crash for unknown tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curvefi/api",
-  "version": "2.68.38",
+  "version": "2.68.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@curvefi/api",
-      "version": "2.68.38",
+      "version": "2.68.39",
       "license": "MIT",
       "dependencies": {
         "@curvefi/ethcall": "^6.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/api",
-  "version": "2.68.38",
+  "version": "2.68.39",
   "description": "JavaScript library for curve.finance",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/route-finder.worker.ts
+++ b/src/route-finder.worker.ts
@@ -77,7 +77,7 @@ export function routeFinderWorker() {
         while (routes.length) {
             const route = routes.pop() as IRouteTvl;
             const inCoin = route.route.length > 0 ? route.route[route.route.length - 1].outputCoinAddress : inputCoinAddress;
-            Object.entries(routerGraph[inCoin]).forEach((leaf) => {
+            Object.entries(routerGraph[inCoin] ?? {}).forEach((leaf) => {
                 const outCoin = leaf[0], steps = leaf[1];
                 if (_isVisitedCoin(outCoin, route)) return;
 


### PR DESCRIPTION
- some llamalend tokens have no curve pool; treat them as "no route" instead of crashing the worker