### PR TITLE
fix: remove unintended console logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/api",
-  "version": "2.69.10",
+  "version": "2.69.11",
   "description": "JavaScript library for curve.finance",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/router.ts
+++ b/src/router.ts
@@ -472,7 +472,6 @@ export async function swap(this: Curve, inputCoin: string, outputCoin: string, a
 }
 
 export async function populateSwap(this: Curve, inputCoin: string, outputCoin: string, amount: number | string, slippage = 0.5): Promise<TransactionLike> {
-    console.log(inputCoin, outputCoin, amount, slippage);
     const [inputCoinAddress, outputCoinAddress] = _getCoinAddresses.call(this, inputCoin, outputCoin);
     const [inputCoinDecimals, outputCoinDecimals] = _getCoinDecimals.call(this, inputCoinAddress, outputCoinAddress);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -765,7 +765,6 @@ export async function getCoinsData(this: Curve, ...coins: string[] | string[][])
     if (coins.length == 1 && Array.isArray(coins[0])) coins = coins[0];
     coins = coins as string[];
     const coinAddresses = _getCoinAddressesNoCheck.call(this, coins);
-    console.log(coinAddresses);
 
     const ethIndex = this.getEthIndex(coinAddresses);
     if (ethIndex !== -1) {


### PR DESCRIPTION
## Summary

- Remove the unconditional console output from `populateSwap`
- Remove the debug logging from `getCoinsData`
- Bump the package version to `2.69.11`

## Motivation

`populateSwap` currently logs the input token, output token, amount, and slippage every time it is called. `getCoinsData` also logs the resolved coin addresses.

These are public library methods, so they should not write debugging information to the consuming application's console. Besides creating noise, the `populateSwap` log can expose transaction parameters in production logs.

This follows the existing project pattern of keeping public API methods free of unintended console output.

## Testing

- `npm run build`
- `npm run lint`
- Added a runtime regression check that invokes both affected code paths with a console spy:
  - Before the change: two `console.log` calls were captured
  - After the change: no `console.log` calls were captured